### PR TITLE
Add Kotlin Android app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+UseByKotlin/.gradle/
+UseByKotlin/build/
+UseByKotlin/app/build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # UseByAndroid
+
+This repository contains a Kotlin + Jetpack Compose Android app scaffold mirroring the core structure of the React Native UseBy app.
+
+The `UseByKotlin` module includes Home, Add Item, Archive, and Settings screens along with placeholders for ads, billing, OCR, AI, and notifications. The code is based on `code.txt`.

--- a/UseByKotlin/app/build.gradle.kts
+++ b/UseByKotlin/app/build.gradle.kts
@@ -1,0 +1,78 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.useby"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.example.useby"
+        minSdk = 24
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+
+        vectorDrawables { useSupportLibrary = true }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+        debug { isMinifyEnabled = false }
+    }
+
+    buildFeatures { compose = true }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+    packaging { resources.excludes += setOf("META-INF/LICENSE*", "META-INF/AL2.0", "META-INF/LGPL2.1") }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2025.01.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    implementation("androidx.compose.material3:material3:1.3.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.8.0")
+
+    // DataStore for simple key-value storage
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
+    // Room (optional if you later want a DB)
+    implementation("androidx.room:room-ktx:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
+
+    // CameraX + ML Kit (OCR placeholder)
+    implementation("androidx.camera:camera-core:1.3.4")
+    implementation("androidx.camera:camera-camera2:1.3.4")
+    implementation("androidx.camera:camera-lifecycle:1.3.4")
+    implementation("androidx.camera:camera-view:1.4.0")
+    implementation("com.google.mlkit:text-recognition:16.0.1")
+
+    // Networking
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+
+    // Google Mobile Ads (Banner / Interstitial / Rewarded)
+    implementation("com.google.android.gms:play-services-ads:23.3.0")
+
+    // Google Play Billing
+    implementation("com.android.billingclient:billing-ktx:7.1.1")
+}

--- a/UseByKotlin/app/proguard-rules.pro
+++ b/UseByKotlin/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/UseByKotlin/app/src/main/AndroidManifest.xml
+++ b/UseByKotlin/app/src/main/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application
+    android:name="android.app.Application"
+    android:label="UseBy"
+    android:icon="@mipmap/ic_launcher"
+    android:usesCleartextTraffic="false">
+
+    <activity
+      android:name=".MainActivity"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
+
+    <!-- AdMob App ID (replace with your real one) -->
+    <meta-data
+      android:name="com.google.android.gms.ads.APPLICATION_ID"
+      android:value="ca-app-pub-XXXXXXXXXXXXXXXX~YYYYYYYYYY"/>
+  </application>
+
+  <uses-permission android:name="android.permission.CAMERA"/>
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+  <uses-permission android:name="android.permission.INTERNET"/>
+</manifest>

--- a/UseByKotlin/app/src/main/java/com/example/useby/MainActivity.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/MainActivity.kt
@@ -1,0 +1,16 @@
+package com.example.useby
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.example.useby.ui.theme.UseByTheme
+import com.example.useby.UseByApp
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            UseByTheme { UseByApp() }
+        }
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/UseByApp.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/UseByApp.kt
@@ -1,0 +1,14 @@
+package com.example.useby
+
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.rememberNavController
+import com.example.useby.nav.UseByNavHost
+
+@Composable
+fun UseByApp() {
+    val nav = rememberNavController()
+    Scaffold { padding ->
+        UseByNavHost(nav, padding)
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ads/AdsManager.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ads/AdsManager.kt
@@ -1,0 +1,5 @@
+package com.example.useby.ads
+
+class AdsManager {
+    // TODO: initialize MobileAds and expose Banner/Interstitial/Rewarded loaders
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ai/OpenAiClient.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ai/OpenAiClient.kt
@@ -1,0 +1,15 @@
+package com.example.useby.ai
+
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.POST
+
+interface OpenAiApi {
+    @Headers("Content-Type: application/json")
+    @POST("/v1/chat/completions")
+    suspend fun chat(@Body body: Map<String, Any>): Map<String, Any>
+}
+
+object OpenAiClient {
+    // TODO: build Retrofit with your API key (from secure storage) and use function to parse OCR text to item + expiry
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/billing/BillingManager.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/billing/BillingManager.kt
@@ -1,0 +1,5 @@
+package com.example.useby.billing
+
+class BillingManager {
+    // TODO: Play Billing integration mirroring RN IAP usage
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/data/LocalStore.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/data/LocalStore.kt
@@ -1,0 +1,28 @@
+package com.example.useby.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+val Context.dataStore by preferencesDataStore("useby_prefs")
+
+class LocalStore(private val context: Context) {
+    private object Keys {
+        val ITEMS = stringSetPreferencesKey("items_json")
+        val MONTHLY_SCANS = intPreferencesKey("monthly_scans")
+    }
+
+    suspend fun saveItems(jsonSet: Set<String>) {
+        context.dataStore.edit { it[Keys.ITEMS] = jsonSet }
+    }
+
+    fun items(): Flow<Set<String>> = context.dataStore.data.map { it[Keys.ITEMS] ?: emptySet() }
+
+    suspend fun setMonthlyScans(v: Int) { context.dataStore.edit { it[Keys.MONTHLY_SCANS] = v } }
+    fun monthlyScans(): Flow<Int> = context.dataStore.data.map { it[Keys.MONTHLY_SCANS] ?: 0 }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/data/Models.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/data/Models.kt
@@ -1,0 +1,12 @@
+package com.example.useby.data
+
+import kotlinx.datetime.LocalDate
+
+data class FoodItem(
+    val id: String,
+    val name: String,
+    val category: String?,
+    val addedDate: LocalDate,
+    val expiryDate: LocalDate?,
+    val archived: Boolean = false
+)

--- a/UseByKotlin/app/src/main/java/com/example/useby/data/Repositories.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/data/Repositories.kt
@@ -1,0 +1,18 @@
+package com.example.useby.data
+
+import kotlinx.coroutines.flow.Flow
+
+interface ItemsRepository {
+    val itemsJson: Flow<Set<String>>
+    suspend fun upsertJson(json: String)
+}
+
+class ItemsRepositoryImpl(private val store: LocalStore): ItemsRepository {
+    override val itemsJson: Flow<Set<String>> = store.items()
+    override suspend fun upsertJson(json: String) {
+        val current = itemsJson
+        // For brevity: decode/encode real JSON later. Here just store set union.
+        // TODO: Replace with Room or kotlinx.serialization.
+        store.saveItems(setOf(json))
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/nav/NavGraph.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/nav/NavGraph.kt
@@ -1,0 +1,25 @@
+package com.example.useby.nav
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.example.useby.ui.screens.*
+
+object Routes {
+    const val HOME = "home"
+    const val ADD = "add"
+    const val ARCHIVE = "archive"
+    const val SETTINGS = "settings"
+}
+
+@Composable
+fun UseByNavHost(nav: NavHostController, padding: PaddingValues) {
+    NavHost(navController = nav, startDestination = Routes.HOME) {
+        composable(Routes.HOME) { HomeScreen(onAdd = { nav.navigate(Routes.ADD) }, onSettings = { nav.navigate(Routes.SETTINGS) }, onArchive = { nav.navigate(Routes.ARCHIVE) }) }
+        composable(Routes.ADD) { AddItemScreen(onDone = { nav.popBackStack() }) }
+        composable(Routes.ARCHIVE) { ArchiveScreen() }
+        composable(Routes.SETTINGS) { SettingsScreen() }
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/notify/Notifier.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/notify/Notifier.kt
@@ -1,0 +1,9 @@
+package com.example.useby.notify
+
+import android.content.Context
+
+object Notifier {
+    fun scheduleExpiryReminder(context: Context, itemId: String) {
+        // TODO: WorkManager/AlarmManager to schedule local notifications
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ocr/OcrManager.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ocr/OcrManager.kt
@@ -1,0 +1,14 @@
+package com.example.useby.ocr
+
+import android.graphics.Bitmap
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import kotlinx.coroutines.tasks.await
+
+object OcrManager {
+    suspend fun recognize(bitmap: Bitmap): String {
+        val recognizer = TextRecognition.getClient()
+        val result = recognizer.process(InputImage.fromBitmap(bitmap, 0)).await()
+        return result.text
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/components/AdBar.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/components/AdBar.kt
@@ -1,0 +1,14 @@
+package com.example.useby.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AdBar() {
+    // TODO: Replace with real AdMob BannerView using ComposeView interop
+    Surface(modifier = Modifier.fillMaxWidth().height(50.dp)) { /* placeholder */ }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/components/Fab.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/components/Fab.kt
@@ -1,0 +1,12 @@
+package com.example.useby.ui.components
+
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.Add
+import androidx.compose.runtime.Composable
+
+@Composable
+fun AddFab(onClick: () -> Unit) {
+    FloatingActionButton(onClick = onClick) { Icon(Icons.Filled.Add, contentDescription = null) }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/components/FoodItemCard.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/components/FoodItemCard.kt
@@ -1,0 +1,17 @@
+package com.example.useby.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FoodItemCard(name: String, expiry: String?) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(name, style = MaterialTheme.typography.titleMedium)
+            if (expiry != null) Text("Expires: $expiry", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/AddItemScreen.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/AddItemScreen.kt
@@ -1,0 +1,23 @@
+package com.example.useby.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AddItemScreen(onDone: () -> Unit) {
+    var name by remember { mutableStateOf("") }
+    var expiry by remember { mutableStateOf("") }
+
+    Scaffold(topBar = { TopAppBar(title = { Text("Add Item") }) }) { padding ->
+        Column(Modifier.padding(padding).padding(16.dp)) {
+            OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Product Name") }, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(value = expiry, onValueChange = { expiry = it }, label = { Text("Expiry Date (YYYY-MM-DD)") }, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = onDone) { Text("Save") }
+        }
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/ArchiveScreen.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/ArchiveScreen.kt
@@ -1,0 +1,9 @@
+package com.example.useby.ui.screens
+
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ArchiveScreen() {
+    Scaffold(topBar = { TopAppBar(title = { Text("Archive") }) }) { }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/HomeScreen.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/HomeScreen.kt
@@ -1,0 +1,28 @@
+package com.example.useby.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.useby.ui.components.AddFab
+import com.example.useby.ui.components.AdBar
+import com.example.useby.ui.components.FoodItemCard
+
+@Composable
+fun HomeScreen(onAdd: () -> Unit, onSettings: () -> Unit, onArchive: () -> Unit) {
+    Scaffold(topBar = { TopAppBar(title = { Text("UseBy") }) }, floatingActionButton = { AddFab(onAdd) }) { padding ->
+        Column(Modifier.padding(padding)) {
+            AdBar()
+            Spacer(Modifier.height(8.dp))
+            LazyColumn(Modifier.fillMaxSize().padding(16.dp)) {
+                items((1..10).map { "Item $it" }) { n ->
+                    FoodItemCard(name = n, expiry = "2025-12-31")
+                    Spacer(Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/SettingsScreen.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/screens/SettingsScreen.kt
@@ -1,0 +1,24 @@
+package com.example.useby.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsScreen() {
+    var premium by remember { mutableStateOf(false) }
+    var scans by remember { mutableStateOf(0) }
+
+    Scaffold(topBar = { TopAppBar(title = { Text("Settings") }) }) { padding ->
+        Column(Modifier.padding(padding).padding(16.dp)) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("Premium")
+                Switch(checked = premium, onCheckedChange = { premium = it })
+            }
+            Spacer(Modifier.height(12.dp))
+            Text("This is a placeholder settings screen.")
+        }
+    }
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/theme/Color.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/theme/Color.kt
@@ -1,0 +1,6 @@
+package com.example.useby.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Placeholder color definitions
+val Purple80 = Color(0xFFD0BCFF)

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/theme/Theme.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/theme/Theme.kt
@@ -1,0 +1,12 @@
+package com.example.useby.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val AppColors = darkColorScheme()
+
+@Composable
+fun UseByTheme(content: @Composable () -> Unit) {
+    MaterialTheme(colorScheme = AppColors, content = content)
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/ui/theme/Type.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/ui/theme/Type.kt
@@ -1,0 +1,6 @@
+package com.example.useby.ui.theme
+
+import androidx.compose.material3.Typography
+
+// Placeholder typography
+val Typography = Typography()

--- a/UseByKotlin/app/src/main/java/com/example/useby/viewmodel/AddItemViewModel.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/viewmodel/AddItemViewModel.kt
@@ -1,0 +1,7 @@
+package com.example.useby.viewmodel
+
+import androidx.lifecycle.ViewModel
+
+class AddItemViewModel: ViewModel() {
+    // TODO: Implement item adding logic
+}

--- a/UseByKotlin/app/src/main/java/com/example/useby/viewmodel/HomeViewModel.kt
+++ b/UseByKotlin/app/src/main/java/com/example/useby/viewmodel/HomeViewModel.kt
@@ -1,0 +1,13 @@
+package com.example.useby.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.useby.data.ItemsRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+class HomeViewModel(repo: ItemsRepository): ViewModel() {
+    val itemsJson: StateFlow<Set<String>> = repo.itemsJson
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+}

--- a/UseByKotlin/build.gradle.kts
+++ b/UseByKotlin/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.7.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
+}

--- a/UseByKotlin/settings.gradle.kts
+++ b/UseByKotlin/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "UseByKotlin"
+include(":app")


### PR DESCRIPTION
## Summary
- add Jetpack Compose Android project scaffold with Home, Add, Archive, and Settings screens
- include placeholders for ads, billing, OCR, AI, and notifications
- document repository and ignore build artifacts

## Testing
- `gradle tasks` *(fails: Plugin [id: 'com.android.application', version: '8.7.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f56cf4ad48321a37f7cc09bbb4c4f